### PR TITLE
Add HEARTH_MONGO_URL to docker-compose for config service

### DIFF
--- a/infrastructure/docker-compose.app.yml
+++ b/infrastructure/docker-compose.app.yml
@@ -578,6 +578,7 @@ services:
       - GATEWAY_URL=http://gateway.{{STACK}}_app_net:7070/
       - DOCUMENTS_URL=http://documents.{{STACK}}_app_net:9050
       - CHECK_INVALID_TOKEN=true
+      - HEARTH_MONGO_URL=mongodb://${STACK}__hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/${STACK}__hearth-dev?replicaSet=rs0
     deploy:
       labels:
         - 'traefik.enable=true'


### PR DESCRIPTION
Add HEARTH_MONGO_URL to allow config service to call mongo directly

Related PR: opencrvs/opencrvs-core#8667