### PR TITLE
feat: Cleanup e2e environment after running tests

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -17,7 +17,11 @@ on:
         type: string
         description: Stack name
         required: true
-
+      keep-e2e:
+        description: Keep environment after run
+        required: true
+        default: true
+        type: boolean
 concurrency:
   group: ${{ github.event.client_payload.stack || github.event.inputs.stack }}
   cancel-in-progress: true
@@ -149,3 +153,35 @@ jobs:
         id: set-output
         run: |
           echo "result=$PREVIOUS_CONCLUSION" >> $GITHUB_OUTPUT
+
+  cleanup-stack:
+    needs: [test]
+    runs-on: ubuntu-24.04
+    if: github.event.client_payload.keep-e2e == 'false' || github.event.inputs.keep-e2e == 'false'
+    env:
+      stack: ${{ github.event.client_payload.stack || github.event.inputs.stack }}
+      keep_e2e: ${{ github.event.client_payload.keep-e2e || github.event.inputs.keep-e2e }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read known hosts
+        run: |
+          echo "KNOWN_HOSTS<<EOF" >> $GITHUB_ENV
+          sed -i -e '$a\' ./infrastructure/known-hosts
+          cat ./infrastructure/known-hosts >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ env.KNOWN_HOSTS }}
+
+      - name: Unset KNOWN_HOSTS variable
+        run: |
+          echo "KNOWN_HOSTS=" >> $GITHUB_ENV
+      - name: Cleanup e2e stack
+        run: |
+          bash infrastructure/deployment/cleanup-e2e-stack.sh \
+          --stack=${stack} \
+          --ssh_host=${{ vars.SSH_HOST || secrets.SSH_HOST }} \
+          --ssh_port=${{ vars.SSH_PORT || secrets.SSH_PORT }} \
+          --ssh_user=${{ secrets.SSH_USER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,13 +82,11 @@ jobs:
           sed -i -e '$a\' ./infrastructure/known-hosts
           cat ./infrastructure/known-hosts >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
-
       - name: Unset KNOWN_HOSTS variable
         run: |
           echo "KNOWN_HOSTS=" >> $GITHUB_ENV

--- a/infrastructure/deployment/cleanup-e2e-stack.sh
+++ b/infrastructure/deployment/cleanup-e2e-stack.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Reading Names parameters
+for i in "$@"; do
+    case $i in
+    --ssh_host=*)
+        SSH_HOST="${i#*=}"
+        shift
+        ;;
+    --ssh_user=*)
+        SSH_USER="${i#*=}"
+        shift
+        ;;
+    --ssh_port=*)
+        SSH_PORT="${i#*=}"
+        shift
+        
+        ;;
+    --stack=*)
+        export STACK="${i#*=}"
+        shift
+        ;;
+    esac
+done
+
+
+print_usage_and_exit () {
+  echo "Usage: $0 --ssh_host --ssh_port --ssh_user --stack"
+  exit 1
+}
+
+validate_options() {
+  if [ -z "$STACK" ] ; then
+    echo 'Error: Argument --stack is required.'
+    print_usage_and_exit
+  fi
+
+  if [ -z "$SSH_HOST" ] ; then
+    echo 'Error: Argument --ssh_host is required.'
+    print_usage_and_exit
+  fi
+
+  if [ -z "$SSH_PORT" ] ; then
+    echo 'Error: Argument --ssh_port is required.'
+    print_usage_and_exit
+  fi
+
+  if [ -z "$SSH_USER" ] ; then
+    echo 'Error: Argument --ssh_user is required.'
+    print_usage_and_exit
+  fi
+
+}
+
+configured_ssh() {
+  # TODO: Remove ~/.ssh/vmudryi-opencrvs
+  ssh $SSH_USER@$SSH_HOST -p $SSH_PORT $SSH_ARGS "$@"
+}
+
+docker_stack_cleanup() {
+  echo "Cleanup docker swarm stack $STACK"
+
+  EXISTING_STACKS=$(configured_ssh 'sudo docker stack ls --format "{{ .Name }}" | grep -v "dependencies" | paste -sd "," -')
+  echo "Existing stacks: $EXISTING_STACKS"
+  if echo $EXISTING_STACKS | grep -w $STACK > /dev/null; then
+    echo "Stack $STACK exists"
+    EXISTING_IMAGES=`mktemp`
+    EXISTING_IMAGES=$(configured_ssh "sudo docker stack services --format '{{.Image}}' '$STACK'" | grep -E '(ghcr.io/opencrvs|opencrvs/ocrvs-farajaland)' | sort)
+    
+    echo "⬤⬤⬤⬤⬤ Deleting stack $STACK ⬤⬤⬤⬤⬤"
+    configured_ssh "sudo docker stack rm $STACK"
+
+    echo "⬤⬤⬤⬤⬤ Deleting images ⬤⬤⬤⬤⬤:"
+    for image in $EXISTING_IMAGES
+    do
+      configured_ssh "sudo docker rmi --force $image && echo ' - [✅ Deleted] $image' || echo ' - [❌ Failed] $image'"
+    done
+  else
+    echo "Stack $STACK doesn't exist. Exiting"
+  fi
+
+  
+
+}
+
+SSH_ARGS=${SSH_ARGS:-}
+
+validate_options
+docker_stack_cleanup


### PR DESCRIPTION
Purpose of this PR is to keep e2e dev server clean from not needed releases.

Current behavior:
- Run deploy on e2e development server on label "🚀 Ready to deploy" added to PR at OpenCRVS Core repository
- Periodically cleanup e2e development server from releases (stacks) that were merged into develop branch or PR's were closed

Suggested change:
- Run deploy on e2e development server for each push to branch, once PR was opened at OpenCRVS Core repository
- Cleanup stack from e2e development server after successful e2e tests run
- Keep stack on e2e development server if one of next is true:
   - e2e tests failed, developer may need to troubleshoot the issue manually
   - `Cleanup environment after run` is set to false, e2e environment is needed for demo, etc

![image](https://github.com/user-attachments/assets/c8b66359-6871-4337-b283-d8e8d795056d)

# test results

- Failed execution example: https://github.com/opencrvs/e2e/actions/runs/13703122918
- Success: https://github.com/opencrvs/e2e/actions/runs/13702895545
