### PR TITLE
fix: extend unique identifier for artifact to allow reruns

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -31,9 +31,9 @@ jobs:
     name: Debug output
     runs-on: ubuntu-22.04
     steps:
-    - name: Print Entire Event Payload
-      run: |
-        echo "${{ toJson(github.event) }}"
+      - name: Print Entire Event Payload
+        run: |
+          echo "${{ toJson(github.event) }}"
   deploy:
     uses: ./.github/workflows/deploy.yml
     with:
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ github.event.client_payload.stack || github.event.inputs.stack }}-${{ steps.artifact.outputs.artifact }}
+          name: playwright-report-${{ github.event.client_payload.stack || github.event.inputs.stack }}-${{ steps.artifact.outputs.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 30
 


### PR DESCRIPTION
Issue was triggered when I had a same branch on both farajaland and on core
```
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

https://github.com/opencrvs/e2e/actions/runs/13923444109/job/38962831025