### PR TITLE
Improve caching for e2e tests

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -72,12 +72,28 @@ jobs:
           path: |
             node_modules
             ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
           key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: Install Dependencies
         run: yarn
+      - uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: npx playwright install --with-deps
+      - name: Cache Node.js dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
+          key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
+          restore-keys: |
+            ${{ runner.os }}-node-
   test:
     needs: [deploy, discover-tests]
     runs-on: ubuntu-22.04
@@ -107,18 +123,13 @@ jobs:
           path: |
             node_modules
             ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
           key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: Install Dependencies
         run: yarn
-
-      - uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: npx playwright install --with-deps
 
       - name: Run Playwright Tests
         run: npx playwright test ./e2e/testcases/${{ matrix.test_file }}

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -128,9 +128,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install Dependencies
-        run: yarn
-
       - name: Run Playwright Tests
         run: npx playwright test ./e2e/testcases/${{ matrix.test_file }}
         env:


### PR DESCRIPTION
Test results:

Before adding top level cache: https://github.com/opencrvs/e2e/actions/runs/14041708141

After adding top level cache: https://github.com/opencrvs/e2e/actions/runs/14040887298

Will we get time benefits of cache?
- Stability, less requests to download packages, less chances of network failure
- Less github runners time



![image](https://github.com/user-attachments/assets/69f32588-b176-41fd-a89d-51af150e7ef1)
