### PR TITLE
e2e integration with Kubernetes cluster

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -1,12 +1,12 @@
 name: Deploy & run E2E
-run-name: 'E2E by ${{ github.event.client_payload.actor || github.actor }} to ${{ github.event.client_payload.stack || github.event.inputs.stack }}. Images core: ${{ github.event.client_payload.core-image-tag || github.event.inputs.core-image-tag }} and farajaland: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}'
+run-name: 'E2E by ${{ github.event.client_payload.actor || github.actor }} to ${{ github.event.client_payload.stack || github.event.inputs.stack }}. (core: ${{ github.event.client_payload.core-image-tag || github.event.inputs.core-image-tag }}, farajaland: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }})'
 on:
   repository_dispatch:
     types: [run_e2e]
   workflow_dispatch:
     inputs:
       core-image-tag:
-        description: Core DockerHub image tag
+        description: Core image tag
         required: true
         default: 'v1.8.0'
       countryconfig-image-tag:
@@ -26,19 +26,68 @@ on:
         description: e2e branch
         required: false
         default: 'develop'
+      runtime:
+        required: false
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - docker
+          - k8s
+      reset:
+        description: reset e2e
+        required: false
+        default: false
+        type: boolean
 concurrency:
-  group: ${{ github.event.client_payload.stack || github.event.inputs.stack }}
+  group: ${{ github.event.client_payload.stack || inputs.stack }}
   cancel-in-progress: true
 
 jobs:
   debug:
     name: Debug output
     runs-on: ubuntu-22.04
+    outputs:
+      runtime: ${{ steps.runtime.outputs.runtime }}
+      domain: ${{ steps.runtime.outputs.domain }}
+      keep_e2e: ${{ steps.runtime.outputs.keep_e2e }}
     steps:
       - name: Print Entire Event Payload
         run: |
           echo "${{ toJson(github.event) }}"
-  deploy:
+      - name: Select docker swarm or k8s
+        # Environment is selected based on stack hash with is always constant
+        # Only first 8 symbols are used from hash and stack_id number is generated
+        # - Odd numbers are deployed to k8s
+        # - Even numbers are deployed to docker swarm
+        # E/g ocrvs-9595 has stack id 2766917431, which means docker
+        id: runtime
+        env:
+          run_id: ${{ github.run_id }}
+          runtime: ${{ github.event.client_payload.runtime || inputs.runtime }}
+          stack: ${{ github.event.client_payload.stack || inputs.stack }}
+          keep_e2e: ${{ github.event.client_payload.keep-e2e || inputs.keep-e2e }}
+        run: |
+          stack_hash=$(echo -n "$stack" | sha256sum | head -c 8)
+          stack_id=$((16#$stack_hash))
+          if [[ "$runtime" != "none" ]]; then
+            runtime="$runtime"
+          elif (( stack_id % 2 == 0 )); then
+            runtime="k8s"
+          else
+            runtime="docker"
+          fi
+          if [[ "$runtime" == "docker" ]]; then
+            domain=${{ github.event.client_payload.stack || inputs.stack }}.${{ vars.DOMAIN }}
+          else
+            domain=${{ github.event.client_payload.stack || inputs.stack }}.k8s-e2e.${{ vars.DOMAIN }}
+          fi
+          echo "domain=$domain" >> $GITHUB_OUTPUT
+          echo "runtime=$runtime" >> $GITHUB_OUTPUT
+          echo "keep_e2e=$keep_e2e" >> $GITHUB_OUTPUT
+  deploy-docker:
+    needs: debug
+    if: needs.debug.outputs.runtime == 'docker'
     uses: ./.github/workflows/deploy.yml
     with:
       core-image-tag: ${{ github.event.client_payload.core-image-tag || github.event.inputs.core-image-tag }}
@@ -47,6 +96,16 @@ jobs:
       dependencies: false
       e2e_branch: ${{ github.event.client_payload.branch || github.event.inputs.branch }}
       reset: 'true'
+    secrets: inherit
+  deploy-k8s:
+    if: needs.debug.outputs.runtime == 'k8s'
+    needs: debug
+    uses: ./.github/workflows/k8s-deploy.yml
+    with:
+      core-image-tag: ${{ github.event.client_payload.core-image-tag || inputs.core-image-tag }}
+      countryconfig-image-tag: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+      environment: ${{ github.event.client_payload.stack || inputs.stack }}
+      reset: ${{ github.event.client_payload.reset || inputs.reset }}
     secrets: inherit
 
   discover-tests:
@@ -83,7 +142,7 @@ jobs:
             node_modules
             ~/.cache/yarn/v6
             ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
+          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
@@ -101,14 +160,21 @@ jobs:
             node_modules
             ~/.cache/yarn/v6
             ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
+          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
   test:
-    needs: [deploy, discover-tests]
-    runs-on: ubuntu-22.04
-    environment: ${{ github.event.client_payload.stack || github.event.inputs.stack }}
+    needs: [debug, deploy-docker, deploy-k8s, discover-tests]
+    # Continue if at least one dependency succeeded (docker OR k8s ran)
+    if: |
+      always() && (
+        needs.deploy-docker.result == 'success' ||
+        needs.deploy-k8s.result == 'success'
+      )
+    runs-on: ubuntu-24.04
+    environment: ${{ github.event.client_payload.stack || inputs.stack }}
     strategy:
+      max-parallel: 10
       fail-fast: false
       matrix:
         test_file: ${{ fromJson(needs.discover-tests.outputs.test_matrix) }}
@@ -121,7 +187,7 @@ jobs:
 
       - name: Checkout country branch
         run: |
-          git checkout ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
+          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
       - name: Set up Node.js from country .nvmrc
         uses: actions/setup-node@v4
         with:
@@ -135,7 +201,7 @@ jobs:
             node_modules
             ~/.cache/yarn/v6
             ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || github.event.inputs.countryconfig-image-tag }}
+          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
@@ -149,9 +215,16 @@ jobs:
           max_attempts: 3
           command: npx playwright install --with-deps
       - name: Run Playwright Tests
-        run: npx playwright test ./e2e/testcases/${{ matrix.test_file }}
+        run: |
+          curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
+          curl -s -o playwright.config.ts https://raw.githubusercontent.com/opencrvs/e2e/refs/heads/k8s-integration/playwright.config.ts
+          npx playwright test ./e2e/testcases/print-certificate/death/36.07-validate-certify-record-page.spec.ts
         env:
-          DOMAIN: '${{ github.event.client_payload.stack || inputs.stack }}.${{ vars.DOMAIN }}'
+          DOMAIN: '${{ needs.debug.outputs.domain }}'
+          # Allow e2e playwright API call for Lets encrypt staging SSL Certificate
+          NODE_EXTRA_CA_CERTS: /tmp/letsencrypt-stg-root-x1.pem
+          # Allow e2e Browser for Lets encrypt staging SSL Certificate
+          IGNORE_CA: '1'
       - id: ctrf_check
         if: always()
         run: |
@@ -170,7 +243,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ github.event.client_payload.stack || github.event.inputs.stack }}-${{ steps.artifact.outputs.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-report-${{ github.event.client_payload.stack || inputs.stack }}-${{ steps.artifact.outputs.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 30
 
@@ -198,13 +271,13 @@ jobs:
         run: |
           echo "result=$PREVIOUS_CONCLUSION" >> $GITHUB_OUTPUT
 
-  cleanup-stack:
-    needs: [test]
+  cleanup-stack-docker:
+    needs: [test, debug]
     runs-on: ubuntu-24.04
-    if: github.event.client_payload.keep-e2e == 'false' || github.event.inputs.keep-e2e == 'false'
+    if: always() && needs.debug.outputs.keep_e2e == 'false' && needs.debug.outputs.runtime == 'docker'
     env:
-      stack: ${{ github.event.client_payload.stack || github.event.inputs.stack }}
-      keep_e2e: ${{ github.event.client_payload.keep-e2e || github.event.inputs.keep-e2e }}
+      stack: ${{ github.event.client_payload.stack || inputs.stack }}
+      keep_e2e: ${{ github.event.client_payload.keep-e2e || inputs.keep-e2e }}
     steps:
       - uses: actions/checkout@v4
       - name: Read known hosts
@@ -229,3 +302,31 @@ jobs:
           --ssh_host=${{ vars.SSH_HOST || secrets.SSH_HOST }} \
           --ssh_port=${{ vars.SSH_PORT || secrets.SSH_PORT }} \
           --ssh_user=${{ secrets.SSH_USER }}
+
+  cleanup-stack-k8s:
+    needs: [test, debug]
+    runs-on: [self-hosted]
+    env:
+      ENV: ${{ github.event.client_payload.stack || inputs.stack }}
+    if: always() && needs.debug.outputs.keep_e2e == 'false' && needs.debug.outputs.runtime == 'k8s'
+    steps:
+        - name: Checkout repo
+          uses: actions/checkout@v4
+        - name: Update k8s-env/opencrvs/values.yaml
+          run: |
+            sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
+        - name: Cleanup environment
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-cleanup
+            helm template -f k8s-env/opencrvs/values.yaml \
+                --set data_cleanup.enabled=true \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                -s templates/data-cleanup-job.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -
+            sleep 30;
+            kubectl logs job/data-cleanup -f --all-containers=true -n opencrvs-${ENV} || true
+            kubectl wait --for=condition=complete job/data-cleanup -n opencrvs-${ENV} --timeout=600s;
+        - name: Delete helm release and namespace
+          run: |
+            kubectl delete namespace opencrvs-${ENV}

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy (k8s)
+run-name: "Deploy OpenCRVS on k8s (core: ${{ inputs.core-image-tag }}, country: ${{ inputs.countryconfig-image-tag }})"
+on:
+    workflow_dispatch:
+      inputs:
+        core-image-tag:
+          description: "Tag of the core image"
+          required: true
+          default: "develop"
+        countryconfig-image-tag:
+          description: "Tag of the countryconfig image"
+          required: true
+          default: "develop"
+        environment:
+          description: "Target environment"
+          required: true
+          default: "demo"
+          type: string
+        reset:
+          description: "Reset environment after deploy"
+          required: false
+          default: false
+          type: boolean
+    workflow_call:
+      inputs:
+        core-image-tag:
+          type: string
+        countryconfig-image-tag:
+          type: string
+        environment:
+          type: string
+        reset:
+          type: boolean
+jobs:
+  deploy:
+    env:
+      ENV: ${{ inputs.environment }}
+      CORE_IMAGE_TAG: ${{ inputs.core-image-tag }}
+      COUNTRYCONFIG_IMAGE_TAG: ${{ inputs.countryconfig-image-tag }}
+    runs-on: [self-hosted]
+    # runs-on: ubuntu-latest
+
+    steps:
+      # FYI: Repository is needed only due to single file: examples/dev/opencrvs-services/values.yaml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Print deployment parameters
+        run: |
+          echo "Environment: $ENV"
+          echo "Core Image: $CORE_IMAGE_TAG"
+          echo "Country Config Image: $COUNTRYCONFIG_IMAGE_TAG"
+      - name: Deploy OpenCRVS MOSIP API
+        run: |
+          helm upgrade --install mosip-api oci://ghcr.io/opencrvs/opencrvs-mosip \
+          --namespace "opencrvs-${ENV}" \
+          -f k8s-env/mosip-api/values.yaml \
+          --set hostname=$ENV.k8s-e2e.opencrvs.dev \
+          --create-namespace
+      - name: Copy secrets from dependencies into application namespace
+        run: |
+          secrets=(
+            "elasticsearch-admin-user"
+            "redis-opencrvs-users"
+            "minio-opencrvs-users"
+            "mongodb-admin-user"
+            "postgres-admin-user"
+          )
+          for secret in "${secrets[@]}"; do
+            kubectl get secret $secret -n opencrvs-deps-e2e -o yaml \
+            | sed "s#namespace: opencrvs-deps-e2e#namespace: opencrvs-${ENV}#" \
+            | grep -vE 'resourceVersion|uid|creationTimestamp' \
+            | kubectl apply -n opencrvs-${ENV} -f - \
+            || echo "Secret $secret doesn't exist in opencrvs-deps-e2e namespace"
+          done
+      - name: Update k8s-env/opencrvs/values.yaml
+        run: |
+          sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
+            --namespace "opencrvs-${ENV}" \
+            -f k8s-env/opencrvs/values.yaml \
+            --create-namespace \
+            --set image.tag="$CORE_IMAGE_TAG" \
+            --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
+            --set hostname=$ENV.k8s-e2e.opencrvs.dev \
+            --set environment="$ENV"
+
+  reset-data:
+    if: ${{ inputs.reset }}
+    # name: Reset environment (k8s)
+    # run-name: "Reset environment (core: ${{ inputs.core-image-tag }})
+    needs: deploy
+    uses: ./.github/workflows/k8s-reset-data.yml
+    with:
+      environment: ${{ inputs.environment }}
+      core-image-tag: ${{ inputs.core-image-tag }}
+    secrets: inherit

--- a/.github/workflows/k8s-reset-data.yml
+++ b/.github/workflows/k8s-reset-data.yml
@@ -1,0 +1,101 @@
+name: Reset environment (k8s)
+run-name: "Reset environment (core: ${{ inputs.core-image-tag }})"
+# FIXME:
+# - replace sleep 30 with kubectl wait for job completion
+on:
+    workflow_dispatch:
+      inputs:
+        core-image-tag:
+          description: "Core image tag"
+          required: true
+          default: "develop"
+          type: string        
+        environment:
+          description: "Target environment"
+          required: true
+          default: "demo"
+          type: choice
+          options:
+            - dev
+            - demo
+    workflow_call:
+      inputs:
+        core-image-tag:
+          type: string
+        environment:
+          type: string
+jobs:
+  reset:
+    env:
+      ENV: ${{ inputs.environment }}
+      CORE_IMAGE_TAG: ${{ inputs.core-image-tag }}
+    runs-on: [self-hosted]
+    steps:
+        # FYI: Repository is needed only due to single file: infrastructure/dev/dependenciess/values.yaml
+        - name: Checkout repo
+          uses: actions/checkout@v4
+        - name: Update k8s-env/opencrvs/values.yaml
+          run: |
+            sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
+        - name: Cleanup environment
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-cleanup
+            helm template -f k8s-env/opencrvs/values.yaml \
+                --set data_cleanup.enabled=true \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                -s templates/data-cleanup-job.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -
+            sleep 30;
+            kubectl logs job/data-cleanup -f --all-containers=true -n opencrvs-${ENV} || true
+            kubectl wait --for=condition=complete job/data-cleanup -n opencrvs-${ENV} --timeout=600s;
+            kubectl delete pod -n opencrvs-${ENV} -lapp=events;
+            kubectl wait --for=condition=ready pod -n opencrvs-${ENV} -lapp=events;
+        - name: Re-run postgres on-deploy
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true postgres-on-deploy;
+            helm template -f k8s-env/opencrvs/values.yaml \
+                -s templates/postgres-on-update.yaml \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -;
+            sleep 30;
+            kubectl logs job/postgres-on-deploy -f --all-containers=true -n opencrvs-${ENV};
+            kubectl wait --for=condition=complete job/postgres-on-deploy -n opencrvs-${ENV} --timeout=600s;
+        - name: Migration
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-migration
+            helm template -f k8s-env/opencrvs/values.yaml \
+                -s templates/data-migration-job.yaml \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -
+            sleep 30;
+            kubectl logs job/data-migration -f -n opencrvs-${ENV} || true
+            kubectl wait --for=condition=complete job/data-migration -n opencrvs-${ENV} --timeout=600s;
+        - name: Re-run postgres on-deploy
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true postgres-on-deploy;
+            helm template -f k8s-env/opencrvs/values.yaml \
+                -s templates/postgres-on-update.yaml \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -;
+            sleep 30;
+            kubectl logs job/postgres-on-deploy -f --all-containers=true -n opencrvs-${ENV};
+            kubectl wait --for=condition=complete job/postgres-on-deploy -n opencrvs-${ENV} --timeout=600s;
+        - name: Seeding data
+          run: |
+            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-seed
+            kubectl delete pod -n opencrvs-${ENV} -lapp=events;
+            kubectl wait --for=condition=ready pod -n opencrvs-${ENV} -lapp=events;
+            helm template  -f k8s-env/opencrvs/values.yaml \
+                --set data_seed.enabled=true \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                -s templates/data-seed-job.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait -f -
+            sleep 30;
+            kubectl logs job/data-seed -f -n opencrvs-${ENV} || true
+            kubectl wait --for=condition=complete job/data-seed -n opencrvs-${ENV} --timeout=600s;
+            kubectl delete pod -n opencrvs-${ENV} -lapp=events;

--- a/.github/workflows/k8s-seed-data.yml
+++ b/.github/workflows/k8s-seed-data.yml
@@ -1,0 +1,52 @@
+name: Seed data (k8s)
+run-name: Seed data to ${{ inputs.environment }} core=${{ inputs.core-image-tag }}
+on:
+    workflow_dispatch:
+      inputs:
+        core-image-tag:
+          description: "Core image tag"
+          required: true
+          default: "develop"
+          type: string        
+        environment:
+          description: "Target environment"
+          required: true
+          default: "demo"
+          type: string
+    workflow_call:
+      inputs:
+        environment:
+          required: true
+          type: string
+        core-image-tag:
+          required: true
+          type: string
+jobs:
+  seed:
+    env:
+      ENV: ${{ inputs.environment }}
+      CORE_IMAGE_TAG: ${{ inputs.core-image-tag }}
+    runs-on: [self-hosted]
+    steps:
+        # FYI: Checkout is needed only due to single file: k8s-env/opencrvs/values.yaml
+        - name: Checkout repo
+          uses: actions/checkout@v4
+        - name: Update k8s-env/opencrvs/values.yaml
+          run: |
+            sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
+        - name: Seeding data
+          run: |
+            kubectl delete job -n opencrvs-${ENV} data-seed || true
+            kubectl delete pod -n opencrvs-${ENV} -lapp=events;
+            sleep 30;
+            kubectl wait --for=condition=ready pod -n opencrvs-${ENV} -lapp=events;
+            helm template  -f k8s-env/opencrvs/values.yaml \
+                --set data_seed.enabled=true \
+                --set image.tag="$CORE_IMAGE_TAG" \
+                --namespace opencrvs-${ENV} \
+                -s templates/data-seed-job.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} -f -
+            sleep 30;
+            kubectl logs job/data-seed -f -n opencrvs-${ENV} || true
+            kubectl wait --for=condition=complete job/data-seed -n opencrvs-${ENV} --timeout=600s;
+            kubectl delete pod -n opencrvs-${ENV} -lapp=events;

--- a/k8s-env/mosip-api/values.yaml
+++ b/k8s-env/mosip-api/values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  ssl_enabled: true

--- a/k8s-env/opencrvs/values.yaml
+++ b/k8s-env/opencrvs/values.yaml
@@ -1,0 +1,159 @@
+chart_dev_mode: false
+
+ingress:
+  tls_resolver: letsencrypt
+
+hostname: k8s-e2e.opencrvs.dev
+influxdb:
+  host: influxdb-0.influxdb.opencrvs-deps-e2e.svc.cluster.local
+elasticsearch:
+  auth_mode: auto
+  port: 9200
+  host: elasticsearch.opencrvs-deps-e2e.svc.cluster.local
+  auth_users:
+    - SEARCH:{{STACK}}_elastic
+    - KIBANA_USER:{{STACK}}_kibana
+    - KIBANA_SYSTEM:{{STACK}}_kibana_system
+    - METRICBEAT:{{STACK}}_beats_system
+    - APM:{{STACK}}_apm_system
+
+minio:
+  auth_mode: use_secret
+  host: minio-0.minio.opencrvs-deps-e2e.svc.cluster.local
+  external_hostname: minio.k8s-e2e.opencrvs.dev
+
+mongodb:
+  auth_mode: auto
+  host: mongodb-0.mongodb.opencrvs-deps-e2e.svc.cluster.local
+  databases:
+    - prefix: USER_MGNT
+      db: {{STACK}}--user-mgnt
+      user: {{STACK}}--user-mgnt
+    - prefix: HEARTH
+      db: {{STACK}}--hearth-dev
+      user: {{STACK}}--hearth
+      roles: "[{ role: 'readWrite', db: '{{STACK}}--hearth' }, { role: 'readWrite', db: 'performance' }, { role: 'readWrite', db: '{{STACK}}--hearth-dev' }]"
+    - prefix: CONFIG
+      db: {{STACK}}--application-config
+      user: {{STACK}}--config
+    - prefix: PERFORMANCE
+      db: {{STACK}}--performance
+      user: {{STACK}}--performance
+    - prefix: METRICS
+      db: {{STACK}}--metrics
+      user: {{STACK}}--metrics
+    - prefix: OPENHIM
+      db: {{STACK}}--openhim-dev
+      user: {{STACK}}--openhim
+      roles: "[{ role: 'readWrite', db: '{{STACK}}--openhim' }, { role: 'readWrite', db: '{{STACK}}--openhim-dev' }]"
+    - prefix: WEBHOOKS
+      db: {{STACK}}--webhooks
+      user: {{STACK}}--webhooks
+    - prefix: NOTIFICATION
+      db: {{STACK}}--notification
+      user: {{STACK}}--notification
+    - prefix: EVENTS
+      db: {{STACK}}--events
+      user: {{STACK}}--events
+      roles: "[{ role: 'readWrite', db: '{{STACK}}--events' }, {role: 'read', db: '{{STACK}}--user-mgnt'}]"
+redis:
+  auth_mode: use_secret
+  host: redis-0.redis.opencrvs-deps-e2e.svc.cluster.local
+
+
+postgres:
+  auth_mode: auto
+  host: postgres-0.postgres.opencrvs-deps-e2e.svc.cluster.local
+  events_db: {{STACK}}__events
+  events_migrator: {{STACK}}_migrator
+  events_app: {{STACK}}_app
+
+resources:
+  memoryRequest: "256Mi"
+  cpuRequest: "200m"
+  memoryLimit: "2Gi"
+  cpuLimit: "1"
+
+image:
+  tag: develop
+
+dashboards:
+  use_default_credentials: false
+
+gateway:
+  resources:
+    memoryRequest: "512Mi"
+    cpuRequest: "200m"
+    memoryLimit: "2Gi"
+    cpuLimit: "1"
+
+config:
+  resources:
+    memoryRequest: "512Mi"
+    cpuRequest: "200m"
+    memoryLimit: "2Gi"
+    cpuLimit: "1"
+
+client:
+  env:
+   CONTENT_SECURITY_POLICY_WILDCARD: "*.k8s-e2e.opencrvs.dev"
+countryconfig:
+  image:
+    # Replace countryconfig with farajaland to test data
+    name: opencrvs/ocrvs-farajaland
+    # name: opencrvs/ocrvs-countryconfig
+    # tag: develop
+    # tag: ec53c12
+    tag: develop
+  env:
+    OPENID_PROVIDER_CLAIMS: name,family_name,given_name,middle_name,birthdate,address
+    OPENID_PROVIDER_CLIENT_ID: mock-client_id
+    V2_EVENTS: "true"
+    # FIXME: In general these values should be passed externally using `--set key=value`
+    ESIGNET_REDIRECT_URL: https://esignet-mock.{{STACK}}.k8s-e2e.opencrvs.dev/authorize
+    MOSIP_API_USERINFO_URL: https://mosip-api.{{STACK}}.k8s-e2e.opencrvs.dev/esignet/get-oidp-user-info
+    # Country config passes minio details to client. 'ocrvs' is hardcoded. To get files working in E2E, countryconfig needs to be configured with the same bucket name as gateway, migration and documents.
+    # E2E prefix intention is to communicate, that this is only for E2E testing and not for production.
+    E2E_MINIO_BUCKET: {{STACK}}--ocrvs
+    # In E2E environment, minio is shared between all services. STACK is omitted from the path. Differentiation is done by bucket name.
+    E2E_MINIO_BASE_URL: https://minio.k8s-e2e.opencrvs.dev
+
+gateway:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
+events:
+  env:
+    ES_INDEX_PREFIX: events_{{STACK}}
+
+search:
+  env:
+    OPENCRVS_INDEX_NAME: ocrvs--{{STACK}}
+metrics:
+  env:
+    INFLUX_DB: {{STACK}}_ocrvs
+user_mgmt:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
+documents:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
+
+data_migration:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
+    INFLUX_DB: {{STACK}}_ocrvs
+    ELASTICSEARCH_INDEX_NAME: ocrvs--{{STACK}}
+
+postgres_on_deploy:
+  env:
+    TARGET_DB: {{STACK}}__events
+
+data_seed:
+  env:
+    SUPER_USER_PASSWORD: "password"
+    ACTIVATE_USERS: "true"
+data_cleanup:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
+    ES_INDEX_PREFIX: events_{{STACK}}
+    ELASTICSEARCH_INDEX_NAME: ocrvs--{{STACK}}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,82 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e/testcases',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Don't retry */
+  retries: process.env.CI ? 3 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html', { open: 'never' }],
+    ['playwright-ctrf-json-reporter', {}]
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+    /* Capture screenshot on failure */
+    screenshot: 'on',
+    /* Collect trace when the test failed. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on',
+    ignoreHTTPSErrors: process.env.IGNORE_CA === '1',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] }
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] }
+    // }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ]
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+})


### PR DESCRIPTION
Goal of this PR is to bring initial support of kubernetes to e2e tests.

Since we don't have much experience running OpenCRVS on Kubernetes this PR will split deployments between docker-swarm and kubernetes runtimes.

For those who would like to test deployment on particular runtime `runtime` input parameter was added.

If `runtime` input was not defined, workflow will use pseudo random selection based on stack name (branch name), that kind of selection will avoid workflow from flip-flop between environments.

Configuration example:
<img width="378" height="530" alt="image" src="https://github.com/user-attachments/assets/8c831a15-ed4d-4dd8-8214-8d769dcdf646" />
