### PR TITLE
fix: Add k8s compatibility point of time

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Print Entire Event Payload
         run: |
           echo "${{ toJson(github.event) }}"
+      - uses: actions/checkout@v4
+        with:
+          repository: 'opencrvs/opencrvs-farajaland'
+          fetch-depth: 0
+
+      - name: Checkout country branch
+        run: |
+          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+
       - name: Select docker swarm or k8s
         # Environment is selected based on stack hash with is always constant
         # Only first 8 symbols are used from hash and stack_id number is generated
@@ -70,7 +79,11 @@ jobs:
         run: |
           stack_hash=$(echo -n "$stack" | sha256sum | head -c 8)
           stack_id=$((16#$stack_hash))
-          if [[ -n "$runtime" && "$runtime" != "none" ]]; then
+          if [[ ! -f infrastructure/.kube ]];
+          then
+            echo "Repository is not compatible with kubernetes"
+            runtime="docker"
+          elif [[ -n "$runtime" && "$runtime" != "none" ]]; then
             runtime="$runtime"
           elif (( stack_id % 2 == 0 )); then
             runtime="k8s"


### PR DESCRIPTION
By this PR we are introducing Kubernetes compatibility to OpenCRVS.

After doing testing on July 21st 2025 we came to conclusion v1.8.0 release is not compatible with existing kubernetes charts and requires more careful review and development.

We need to take a time and think rolling kubernetes support for future releases and don't try to add compatibility to previous one.

File infrustructure/.kube is used to give e2e pipeline a point of time for deployment

Mature docker swarm solution will become legacy in the future releases and will be replaced by kubernetes.