### PR TITLE
feat: Added retry to e2e tests

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -231,10 +231,14 @@ jobs:
           max_attempts: 3
           command: npx playwright install --with-deps
       - name: Run Playwright Tests
-        run: |
-          curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
-          curl -s -o playwright.config.ts https://raw.githubusercontent.com/opencrvs/e2e/refs/heads/k8s-integration/playwright.config.ts
-          npx playwright test ./e2e/testcases/${{ matrix.test_file }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          command: |
+            curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
+            curl -s -o playwright.config.ts https://raw.githubusercontent.com/opencrvs/e2e/refs/heads/k8s-integration/playwright.config.ts
+            npx playwright test ./e2e/testcases/${{ matrix.test_file }}
         env:
           DOMAIN: '${{ needs.debug.outputs.domain }}'
           # Allow e2e playwright API call for Lets encrypt staging SSL Certificate


### PR DESCRIPTION
Following changes are introduced:
- Retry on failure (only one additional attempt
- Timeout 10 minutes, usually tests are taking from 1 to 5 minutes