### PR TITLE
Chore/use shards over files on matrix

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           export NODE_EXTRA_CA_CERTS=/tmp/letsencrypt-stg-root-x1.pem
           curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
-          npx playwright test --shard=${{ matrix.shard }}/10
+          npx playwright test --shard=${{ matrix.shard }}/20
         env:
           DOMAIN: '${{ needs.debug.outputs.domain }}'
       - id: ctrf_check
@@ -284,23 +284,23 @@ jobs:
       ENV: ${{ github.event.client_payload.stack || inputs.stack }}
     if: always() && needs.debug.outputs.keep_e2e == 'false' && needs.debug.outputs.runtime == 'k8s' && needs.test.result == 'success'
     steps:
-        - name: Checkout repo
-          uses: actions/checkout@v4
-        - name: Update k8s-env/opencrvs/values.yaml
-          run: |
-            sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
-        - name: Cleanup environment
-          run: |
-            kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-cleanup
-            helm template -f k8s-env/opencrvs/values.yaml \
-                --set data_cleanup.enabled=true \
-                --set image.tag="$CORE_IMAGE_TAG" \
-                --namespace opencrvs-${ENV} \
-                -s templates/data-cleanup-job.yaml \
-                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -
-            sleep 30;
-            kubectl logs job/data-cleanup -f --all-containers=true -n opencrvs-${ENV} || true
-            kubectl wait --for=condition=complete job/data-cleanup -n opencrvs-${ENV} --timeout=600s;
-        - name: Delete helm release and namespace
-          run: |
-            kubectl delete namespace opencrvs-${ENV}
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Update k8s-env/opencrvs/values.yaml
+        run: |
+          sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml
+      - name: Cleanup environment
+        run: |
+          kubectl delete job -n opencrvs-${ENV} --ignore-not-found=true data-cleanup
+          helm template -f k8s-env/opencrvs/values.yaml \
+              --set data_cleanup.enabled=true \
+              --set image.tag="$CORE_IMAGE_TAG" \
+              --namespace opencrvs-${ENV} \
+              -s templates/data-cleanup-job.yaml \
+              oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n opencrvs-${ENV} --wait=true -f -
+          sleep 30;
+          kubectl logs job/data-cleanup -f --all-containers=true -n opencrvs-${ENV} || true
+          kubectl wait --for=condition=complete job/data-cleanup -n opencrvs-${ENV} --timeout=600s;
+      - name: Delete helm release and namespace
+        run: |
+          kubectl delete namespace opencrvs-${ENV}

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -119,54 +119,8 @@ jobs:
       reset: ${{ github.event.client_payload.reset || inputs.reset || true }}
       keep-e2e: ${{ github.event.client_payload.keep-e2e == 'true' || github.event.client_payload.keep-e2e == true || inputs.keep-e2e || false }}
     secrets: inherit
-  discover-tests:
-    name: Discover test directories
-    runs-on: ubuntu-24.04
-    outputs:
-      test_matrix: ${{ steps.list-tests.outputs.test_matrix }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: 'opencrvs/opencrvs-farajaland'
-          fetch-depth: 0
-
-      - name: Checkout country branch
-        run: |
-          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
-
-      - name: Set up Node.js from country .nvmrc
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-
-      - name: List Test Directories
-        id: list-tests
-        run: |
-          tests_suites=$(cd e2e/testcases; find * -type f -name "*.spec.ts" | jq -R -s -c 'split("\n")[:-1]')
-          echo "Test suites: $tests_suites"
-          echo "test_matrix=$tests_suites" >> $GITHUB_OUTPUT
-          echo "test_matrix=$tests_suites"
-      - name: Cache Node.js dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            ~/.cache/yarn/v6
-            ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install Dependencies
-        run: yarn
-      - uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: npx playwright install --with-deps
-
   test:
-    needs: [debug, deploy-docker, deploy-k8s, discover-tests]
+    needs: [debug, deploy-docker, deploy-k8s]
     # Continue if at least one dependency succeeded (docker OR k8s ran)
     if: |
       always() && (
@@ -179,8 +133,8 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        test_file: ${{ fromJson(needs.discover-tests.outputs.test_matrix) }}
-    name: ${{ matrix.test_file }}
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    name: shard-${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -219,8 +173,8 @@ jobs:
       - name: Run Playwright Tests
         run: |
           export NODE_EXTRA_CA_CERTS=/tmp/letsencrypt-stg-root-x1.pem
-          curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem;
-          npx playwright test ./e2e/testcases/${{ matrix.test_file }}
+          curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
+          npx playwright test --shard=${{ matrix.shard }}/10
         env:
           DOMAIN: '${{ needs.debug.outputs.domain }}'
       - id: ctrf_check
@@ -237,15 +191,11 @@ jobs:
           summary-report: true
           test-report: true
         if: always() && steps.ctrf_check.outputs.ctrf == 'true'
-      - name: Form the artifact name from test_file
-        if: always()
-        id: artifact
-        run: echo "artifact=$(echo '${{ matrix.test_file }}' | sed 's/\//__/g')" >> $GITHUB_OUTPUT
-
-      - uses: actions/upload-artifact@v4
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ github.event.client_payload.stack || inputs.stack }}-${{ steps.artifact.outputs.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-report-${{ github.event.client_payload.stack || inputs.stack }}-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 30
 

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -133,7 +133,29 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20
+          ]
     name: shard-${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
1. We have > 150 test files.
2. Each file needs its own runner
3. During peak hours, runners are a bottleneck (example:  https://github.com/opencrvs/e2e/actions/runs/17293988656)
4. By creating smaller shards, optimized by playwright, tests will run more evenly, faster and with less runners