### PR TITLE
fix: create namespace as separate step

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -1,44 +1,44 @@
 name: Deploy (k8s)
-run-name: "Deploy OpenCRVS on k8s (core: ${{ inputs.core-image-tag }}, country: ${{ inputs.countryconfig-image-tag }})"
+run-name: 'Deploy OpenCRVS on k8s (core: ${{ inputs.core-image-tag }}, country: ${{ inputs.countryconfig-image-tag }})'
 on:
-    workflow_call:
-      inputs:
-        core-image-tag:
-          type: string
-        countryconfig-image-tag:
-          type: string
-        environment:
-          type: string
-        reset:
-          type: boolean
-        keep-e2e:
-          type: boolean
-          default: false
-    workflow_dispatch:
-      inputs:
-        core-image-tag:
-          description: "Tag of the core image"
-          required: true
-          default: "develop"
-        countryconfig-image-tag:
-          description: "Tag of the countryconfig image"
-          required: true
-          default: "develop"
-        environment:
-          description: "Target environment"
-          required: true
-          default: "demo"
-          type: string
-        reset:
-          description: "Reset environment after deploy"
-          required: false
-          default: false
-          type: boolean
-        keep-e2e:
-          description: "Add keep_namespace label"
-          required: false
-          type: boolean
-          default: false
+  workflow_call:
+    inputs:
+      core-image-tag:
+        type: string
+      countryconfig-image-tag:
+        type: string
+      environment:
+        type: string
+      reset:
+        type: boolean
+      keep-e2e:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      core-image-tag:
+        description: 'Tag of the core image'
+        required: true
+        default: 'develop'
+      countryconfig-image-tag:
+        description: 'Tag of the countryconfig image'
+        required: true
+        default: 'develop'
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'demo'
+        type: string
+      reset:
+        description: 'Reset environment after deploy'
+        required: false
+        default: false
+        type: boolean
+      keep-e2e:
+        description: 'Add keep_namespace label'
+        required: false
+        type: boolean
+        default: false
 jobs:
   deploy:
     env:
@@ -61,13 +61,19 @@ jobs:
           echo "Environment: $ENV"
           echo "Core Image: $CORE_IMAGE_TAG"
           echo "Country Config Image: $COUNTRYCONFIG_IMAGE_TAG"
+        # Create namespace separately from deployments. With two separate deployments (mosip & e2e), if other fails, we still want to be able to clean it based on updated_at)
+      - name: Ensure namespace exists with updated_at label
+        run: |
+          if ! kubectl get namespace "opencrvs-${ENV}" >/dev/null 2>&1; then
+            kubectl create namespace "opencrvs-${ENV}"
+          fi
+          kubectl label namespace --overwrite "opencrvs-${ENV}" updated_at=$(date +%s)
       - name: Deploy OpenCRVS MOSIP API
         run: |
           helm upgrade --install mosip-api oci://ghcr.io/opencrvs/opencrvs-mosip \
           --namespace "opencrvs-${ENV}" \
           -f k8s-env/mosip-api/values.yaml \
           --set hostname=$ENV.k8s-e2e.opencrvs.dev \
-          --create-namespace \
           --atomic
       - name: Copy secrets from dependencies into application namespace
         run: |
@@ -94,7 +100,6 @@ jobs:
             --timeout 15m \
             --namespace "opencrvs-${ENV}" \
             -f k8s-env/opencrvs/values.yaml \
-            --create-namespace \
             --atomic \
             --set image.tag="$CORE_IMAGE_TAG" \
             --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
@@ -118,6 +123,6 @@ jobs:
     needs: deploy
     uses: ./.github/workflows/k8s-reset-data.yml
     with:
-      namespace: "opencrvs-${{ inputs.environment }}"
+      namespace: 'opencrvs-${{ inputs.environment }}'
       environment: ${{ inputs.environment }}
     secrets: inherit

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -61,7 +61,7 @@ jobs:
           echo "Environment: $ENV"
           echo "Core Image: $CORE_IMAGE_TAG"
           echo "Country Config Image: $COUNTRYCONFIG_IMAGE_TAG"
-        # Create namespace separately from deployments. With two separate deployments (mosip & e2e), if other fails, we still want to be able to clean it based on updated_at)
+        # Create namespace separately from deployments. With two separate deployments (mosip & e2e), if other fails, we still want to be able to clean it based on updated_at.
       - name: Ensure namespace exists with updated_at label
         run: |
           if ! kubectl get namespace "opencrvs-${ENV}" >/dev/null 2>&1; then


### PR DESCRIPTION
Create namespace separately from deployments. With two separate deployments (mosip & e2e), if other fails, we still want to be able to clean it based on updated_at.