### PR TITLE
fix: Install dependencies before running e2e shards

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Print Entire Event Payload
         run: |
           echo "${{ toJson(github.event) }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: 'opencrvs/opencrvs-farajaland'
           fetch-depth: 0
@@ -94,6 +94,50 @@ jobs:
           echo "runtime=$runtime" >> $GITHUB_OUTPUT
           echo "domain=$domain"
           echo "runtime=$runtime"
+  cache-node-js:
+    name: Cache Node.js dependencies
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          repository: 'opencrvs/opencrvs-farajaland'
+          fetch-depth: 0
+
+      - name: Checkout country branch
+        run: |
+          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+      - name: Set up Node.js from country .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Cache Node.js dependencies
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
+          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        uses: nick-fields/retry@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: yarn
+      - uses: nick-fields/retry@v3
+        name: Install Playwright Browsers
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: npx playwright install --with-deps
+
   deploy-docker:
     needs: debug
     if: needs.debug.outputs.runtime == 'docker'
@@ -118,7 +162,7 @@ jobs:
       keep-e2e: ${{ github.event.client_payload.keep-e2e == 'true' || github.event.client_payload.keep-e2e == true || inputs.keep-e2e || false }}
     secrets: inherit
   test:
-    needs: [debug, deploy-docker, deploy-k8s]
+    needs: [debug, deploy-docker, deploy-k8s, cache-node-js]
     # Continue if at least one dependency succeeded (docker OR k8s ran)
     if: |
       always() && (
@@ -156,7 +200,7 @@ jobs:
           ]
     name: shard-${{ matrix.shard }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: 'opencrvs/opencrvs-farajaland'
           fetch-depth: 0
@@ -251,7 +295,7 @@ jobs:
       stack: ${{ github.event.client_payload.stack || inputs.stack }}
       keep_e2e: ${{ github.event.client_payload.keep-e2e || inputs.keep-e2e }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Read known hosts
         run: |
           echo "KNOWN_HOSTS<<EOF" >> $GITHUB_ENV
@@ -283,7 +327,7 @@ jobs:
     if: always() && needs.debug.outputs.keep_e2e == 'false' && needs.debug.outputs.runtime == 'k8s'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update k8s-env/opencrvs/values.yaml
         run: |
           sed -i -e "s#{{STACK}}#${ENV}#g" k8s-env/opencrvs/values.yaml

--- a/k8s-env/opencrvs/values.yaml
+++ b/k8s-env/opencrvs/values.yaml
@@ -84,6 +84,8 @@ dashboards:
   enabled: false
 
 gateway:
+  env:
+    MINIO_BUCKET: {{STACK}}--ocrvs
   resources:
     memoryRequest: "512Mi"
     cpuRequest: "200m"
@@ -96,11 +98,6 @@ config:
     cpuRequest: "200m"
     memoryLimit: "2Gi"
     cpuLimit: "1"
-
-events:
-  resources:
-    memoryRequest: "1Gi"
-    cpuRequest: "500m"
 
 client:
   env:
@@ -126,9 +123,8 @@ countryconfig:
     # In E2E environment, minio is shared between all services. STACK is omitted from the path. Differentiation is done by bucket name.
     E2E_MINIO_BASE_URL: https://minio.k8s-e2e.opencrvs.dev
 
-gateway:
-  env:
-    MINIO_BUCKET: {{STACK}}--ocrvs
+
+
 events:
   env:
     ES_INDEX_PREFIX: events_{{STACK}}
@@ -179,3 +175,4 @@ data_cleanup:
 
 env:
   APN_SERVICE_URL: "http://apm-server.opencrvs-deps-e2e.svc.cluster.local:8200"
+  APN_ENVIRONMENT: {{STACK}}


### PR DESCRIPTION
Goal of this PR is to mitigate 2 issues:
- Reduce number of requests to yarn package repository: https://github.com/opencrvs/e2e/actions/runs/17916429734/job/50940218898
   ```
    error Error: https://registry.yarnpkg.com/@types/csv2json/-/csv2json-1.4.5.tgz: Request failed "500 Internal Server Error"
   ```
- Avoid per-shard installation: https://github.com/opencrvs/e2e/actions/runs/17916429734/job/50940218811
   <img width="1510" height="510" alt="image" src="https://github.com/user-attachments/assets/5b1c90f8-3469-4f04-a3c0-6f0ba4ff419b" />
