### PR TITLE
fix: All jobs responsible for initial configuration will have -on-dep…

### DIFF
--- a/.github/workflows/k8s-reset-data.yml
+++ b/.github/workflows/k8s-reset-data.yml
@@ -64,9 +64,9 @@ jobs:
       matrix:
         job-name:
           - data-cleanup
-          - postgres-on-update-core
-          - postgres-on-update-analytics
+          - postgres-on-deploy
           - data-migration
+          - data-migration-analytics
           - data-seed
           - elasticsearch-reindex
     steps:


### PR DESCRIPTION
## Description

This PR aims to ship changes for issue https://github.com/opencrvs/opencrvs-core/issues/11192

See PR: https://github.com/opencrvs/infrastructure/pull/209

## Testing

Workflow: https://github.com/opencrvs/e2e/actions/runs/21037333705/job/60488910868

Custom branch from infrastructure repository was used: ocrvs-11192-fix-naming

<img width="750" height="298" alt="image" src="https://github.com/user-attachments/assets/d2fda3b1-2c8f-439b-99e3-81ee993f46c3" />

New job names were applied:

| Old name | new name | Changed |
|---|---|---|
| data-cleanup | data-cleanup |  🙅   |
| postgres-on-update-core | postgres-on-deploy | 👍  |
| data-migration | data-migration | 🙅   |
| postgres-on-update-analytics |  data-migration-analytics | 👍  |

<img width="1347" height="585" alt="image" src="https://github.com/user-attachments/assets/41696538-3a62-454a-8c38-98bca9043fa0" />
