### PR TITLE
Cleanup e2e environment before running deployment

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -48,6 +48,27 @@ jobs:
       - name: Print Entire Event Payload
         run: |
           echo "${{ toJson(github.event) }}"
+  check-env-existance:
+    name: Check if environment exists
+    runs-on: [self-hosted, k8s, e2e]
+    outputs:
+      exists: ${{ steps.check.outputs.status }}
+    steps:
+    - name: check namespace
+      id: check
+      env:
+        ENV: ${{ github.event.client_payload.stack || inputs.stack }}
+      run: |
+        kubectl get ns opencrvs-${ENV} && status=true || status=false
+        echo "status=$status"  >> $GITHUB_OUTPUT
+  reset-data:
+    needs: [check-env-existance]
+    if: needs.check-env-existance.outputs.exists == 'true' && (github.event.client_payload.reset || inputs.reset || true) 
+    uses: ./.github/workflows/k8s-reset-data.yml
+    with:
+      environment: ${{ github.event.client_payload.stack || inputs.stack }}
+      chart-branch: ${{ inputs.chart-branch }}
+    secrets: inherit
 
   cache-node-js:
     name: Cache Node.js dependencies
@@ -95,17 +116,19 @@ jobs:
 
   deploy:
     uses: ./.github/workflows/k8s-deploy.yml
+    if: always()
+    needs: reset-data
     with:
       core-image-tag: ${{ github.event.client_payload.core-image-tag || inputs.core-image-tag }}
       countryconfig-image-tag: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
       environment: ${{ github.event.client_payload.stack || inputs.stack }}
-      reset: ${{ github.event.client_payload.reset || inputs.reset || true }}
       chart-branch: ${{ github.event.client_payload.chart-branch || inputs.chart-branch }}
       keep-e2e: ${{ github.event.client_payload.keep-e2e == 'true' || github.event.client_payload.keep-e2e == true || inputs.keep-e2e || false }}
     secrets: inherit
 
   test:
     needs: [debug, deploy, cache-node-js]
+    if: always() && needs.deploy.result == 'success'
     runs-on: ubuntu-24.04
     environment: ${{ github.event.client_payload.stack || inputs.stack }}
     strategy:
@@ -229,7 +252,7 @@ jobs:
     runs-on: [self-hosted]
     env:
       ENV: ${{ github.event.client_payload.stack || inputs.stack }}
-    if: inputs.keep-e2e != 'true' && inputs.keep-e2e != true && github.event.client_payload.keep-e2e != 'true' && github.event.client_payload.keep-e2e != true
+    if: always() && needs.test.result == 'success' && inputs.keep-e2e != 'true' && inputs.keep-e2e != true && github.event.client_payload.keep-e2e != 'true' && github.event.client_payload.keep-e2e != true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -11,8 +11,6 @@ on:
         type: string
       environment:
         type: string
-      reset:
-        type: boolean
       keep-e2e:
         type: boolean
         default: false
@@ -35,11 +33,6 @@ on:
         required: true
         default: 'demo'
         type: string
-      reset:
-        description: 'Reset environment after deploy'
-        required: false
-        default: false
-        type: boolean
       keep-e2e:
         description: 'Add keep_namespace label'
         required: false
@@ -69,7 +62,7 @@ jobs:
           echo "Deploying environment to https://${{ inputs.environment }}.e2e-k8s.${{ vars.DOMAIN }}" >> $GITHUB_STEP_SUMMARY
           echo "Core image tag: ${{ inputs.core-image-tag }}" >> $GITHUB_STEP_SUMMARY
           echo "Country config image tag: ${{ inputs.countryconfig-image-tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "Reset environment: ${{ inputs.reset }}" >> $GITHUB_STEP_SUMMARY
+
       - name: Print deployment parameters
         run: |
           echo "Environment: $ENV"
@@ -128,6 +121,7 @@ jobs:
             --set image.tag="$CORE_IMAGE_TAG" \
             --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
             --set hostname=$ENV.e2e-k8s.opencrvs.dev \
+            --set data_seed.enabled=true \
             --set environment="$ENV" 2>&1 | sed '/USER-SUPPLIED VALUES:/,$d'; STATUS=${PIPESTATUS[0]};
             kill $STERN_PID 2>/dev/null || true
             exit $STATUS
@@ -144,12 +138,3 @@ jobs:
           jq -r '.items[] | select(.metadata.labels.status=="pending-install" or .metadata.labels.status=="pending-upgrade" or .metadata.labels.status=="pending-rollback") | .metadata.name' | \
           xargs -r kubectl -n "opencrvs-${ENV}" delete secret || \
           echo "No helm locks found, all is good"
-
-  reset-data:
-    if: ${{ inputs.reset }}
-    needs: deploy
-    uses: ./.github/workflows/k8s-reset-data.yml
-    with:
-      environment: ${{ inputs.environment }}
-      chart-branch: ${{ inputs.chart-branch }}
-    secrets: inherit


### PR DESCRIPTION
# Description

Goal of this PR is to cleanup e2e environment from inconsistent data before running deployment

# Testing

## Test 1

New environment deployment: https://github.com/opencrvs/e2e/actions/runs/23947460095

Expected behaviour: Cleanup job skipped
<img width="1441" height="594" alt="image" src="https://github.com/user-attachments/assets/e9da9718-4334-47e2-80bf-81a0a0677a5d" />


## Test 2

Existing environment deployment:  https://github.com/opencrvs/e2e/actions/runs/23947460095/job/69846929320

Expected behaviour: 

## Test 3

Existing environment in broken stage: https://github.com/opencrvs/e2e/actions/runs/23945256124

Expected behaviour: Cleanup fails
Reason: helm chart was not deployed, but namespace exists
<img width="1037" height="314" alt="image" src="https://github.com/user-attachments/assets/6d601747-d68b-4a41-b056-24150f279478" />
