### PR TITLE
fix: checkout provided branch

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -124,6 +124,7 @@ jobs:
       environment: ${{ github.event.client_payload.stack || inputs.stack }}
       chart-branch: ${{ github.event.client_payload.chart-branch || inputs.chart-branch }}
       keep-e2e: ${{ github.event.client_payload.keep-e2e == 'true' || github.event.client_payload.keep-e2e == true || inputs.keep-e2e || false }}
+      branch: ${{ github.event.client_payload.branch || inputs.branch }}
     secrets: inherit
 
   test:

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -14,6 +14,9 @@ on:
       keep-e2e:
         type: boolean
         default: false
+      branch:
+        type: string
+        default: 'develop'
   workflow_dispatch:
     inputs:
       core-image-tag:
@@ -38,6 +41,10 @@ on:
         required: false
         type: boolean
         default: false
+      branch:
+        description: 'e2e branch'
+        required: false
+        default: 'develop'
 jobs:
   deploy:
     env:
@@ -48,6 +55,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
       - name: Checkout OpenCRVS helm charts repository ${{ inputs.chart-branch }}
         uses: actions/checkout@v6
         with:

--- a/k8s-env/opencrvs/values.yaml
+++ b/k8s-env/opencrvs/values.yaml
@@ -47,9 +47,6 @@ mongodb:
       db: {{STACK}}--events
       user: {{STACK}}--events
       roles: "[{ role: 'readWrite', db: '{{STACK}}--events' }, {role: 'read', db: '{{STACK}}--user-mgnt'}]"
-    - prefix: WEBHOOKS
-      db: {{STACK}}--webhooks
-      user: {{STACK}}--webhooks
 redis:
   auth_mode: use_secret
   host: redis-0.redis.opencrvs-deps-e2e.svc.cluster.local

--- a/k8s-env/opencrvs/values.yaml
+++ b/k8s-env/opencrvs/values.yaml
@@ -37,9 +37,6 @@ mongodb:
       db: {{STACK}}--hearth-dev
       user: {{STACK}}--hearth
       roles: "[{ role: 'readWrite', db: '{{STACK}}--hearth' }, { role: 'readWrite', db: 'performance' }, { role: 'readWrite', db: '{{STACK}}--hearth-dev' }]"
-    - prefix: CONFIG
-      db: {{STACK}}--application-config
-      user: {{STACK}}--config
     - prefix: PERFORMANCE
       db: {{STACK}}--performance
       user: {{STACK}}--performance


### PR DESCRIPTION
The e2e branch to use that was being proved to the "Deploy & run E2E" workflow was not being forwarded to "Deploy (k8s)" workflow causing it to always use "develop"