### PR TITLE
fix: remove the to_string conversion from workflows

### DIFF
--- a/.github/workflows/k8s-reset-data.yml
+++ b/.github/workflows/k8s-reset-data.yml
@@ -1,10 +1,10 @@
 name: Reset environment
-run-name: "Reset ${{ inputs.environment }} environment"
+run-name: 'Reset ${{ inputs.environment }} environment'
 on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Target environment"
+        description: 'Target environment'
         required: true
         type: string
       chart-branch:
@@ -28,17 +28,7 @@ jobs:
       - name: Get helm release values and Quote specific fields that are commonly numeric
         id: get-values
         run: |
-          helm get values opencrvs -n ${namespace} -ojson | \
-            jq '
-              # Quote OpenCRVS core image tags
-              if has("image") and (.image | has("tag")) and (.image.tag | type == "number") then
-                .image.tag = (.image.tag | tostring)
-              else . end |
-              # Quote Countryconfig image tags
-              if has("countryconfig") and (.countryconfig | has("image")) and (.countryconfig.image.tag | type == "number") then
-                .countryconfig.image.tag = (.countryconfig.image.tag | tostring)
-              else . end
-            ' > /tmp/${namespace}.json
+          helm get values opencrvs -n ${namespace} -ojson > /tmp/${namespace}.json
             echo "values-file=/tmp/${namespace}.json" >> $GITHUB_OUTPUT
       - name: Upload helm release values file /tmp/opencrvs-${{ inputs.environment }}.json
         uses: actions/upload-artifact@v7
@@ -53,8 +43,8 @@ jobs:
       namespace: opencrvs-${{ inputs.environment }}
     runs-on: [self-hosted, k8s, e2e]
     strategy:
-      max-parallel: 1  # Ensure jobs run one by one
-      fail-fast: true  # Stop on first failure
+      max-parallel: 1 # Ensure jobs run one by one
+      fail-fast: true # Stop on first failure
       matrix:
         job-name:
           - data-cleanup
@@ -64,42 +54,42 @@ jobs:
           - data-seed
           - elasticsearch-reindex
     steps:
-        - name: Checkout repo
-          uses: actions/checkout@v6
-        - name: Checkout OpenCRVS helm charts repository ${{ inputs.chart-branch }}
-          uses: actions/checkout@v6
-          with:
-            repository: opencrvs/opencrvs-helm-charts
-            path: infrastructure
-            ref: ${{ inputs.chart-branch }}
-        - name: Verify branch status ${{ inputs.chart-branch }}
-          working-directory: infrastructure
-          run: git status
-        - name: Download helm release values file into /tmp/opencrvs-${{ inputs.environment }}.json
-          uses: actions/download-artifact@v8
-          with:
-            name: opencrvs-${{ inputs.environment }}-values-file
-            path: /tmp
-        - name: Create job ${{ matrix.job-name }} from helm template and apply it
-          run: |
-            kubectl delete job -n ${namespace} --ignore-not-found=true ${{ matrix.job-name }}
-            helm template -f ${{ needs.prepare.outputs.values-file }} \
-                --set data_cleanup.enabled=true \
-                --set data_seed.enabled=true \
-                --namespace ${namespace} \
-                -s templates/${{ matrix.job-name }}-job.yaml \
-                infrastructure/charts/opencrvs-services | kubectl apply -n ${namespace} --wait=true -f -
-        - name: Checking ${{ matrix.job-name }} job status
-          run: |
-            while true; do
-              kubectl wait --for=condition=ready pod -ljob-name=${{ matrix.job-name }} --timeout=300s -n ${namespace} && \
-              kubectl logs job/${{ matrix.job-name }} --all-containers -f -n ${namespace} && \
-              touch /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt || break; 
-              sleep 1; done &
-            echo "---------------------- Waiting for job completion ----------------------"
-            kubectl wait --for=condition=complete job/${{ matrix.job-name }} -n ${namespace} --timeout=600s; status=$? || true
-            [ $status -ne 0 ] && kubectl get pods -n ${namespace} --show-labels && kubectl describe pod -ljob-name=${job_name} -n ${namespace};
-            [ ! -f /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt ] && kubectl logs job/${{ matrix.job-name }} --all-containers -n ${namespace} || \
-              rm -vf /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt
-            kill %1 2>/dev/null && echo "Stopped log streaming" || true
-            exit $status
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Checkout OpenCRVS helm charts repository ${{ inputs.chart-branch }}
+        uses: actions/checkout@v6
+        with:
+          repository: opencrvs/opencrvs-helm-charts
+          path: infrastructure
+          ref: ${{ inputs.chart-branch }}
+      - name: Verify branch status ${{ inputs.chart-branch }}
+        working-directory: infrastructure
+        run: git status
+      - name: Download helm release values file into /tmp/opencrvs-${{ inputs.environment }}.json
+        uses: actions/download-artifact@v8
+        with:
+          name: opencrvs-${{ inputs.environment }}-values-file
+          path: /tmp
+      - name: Create job ${{ matrix.job-name }} from helm template and apply it
+        run: |
+          kubectl delete job -n ${namespace} --ignore-not-found=true ${{ matrix.job-name }}
+          helm template -f ${{ needs.prepare.outputs.values-file }} \
+              --set data_cleanup.enabled=true \
+              --set data_seed.enabled=true \
+              --namespace ${namespace} \
+              -s templates/${{ matrix.job-name }}-job.yaml \
+              infrastructure/charts/opencrvs-services | kubectl apply -n ${namespace} --wait=true -f -
+      - name: Checking ${{ matrix.job-name }} job status
+        run: |
+          while true; do
+            kubectl wait --for=condition=ready pod -ljob-name=${{ matrix.job-name }} --timeout=300s -n ${namespace} && \
+            kubectl logs job/${{ matrix.job-name }} --all-containers -f -n ${namespace} && \
+            touch /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt || break; 
+            sleep 1; done &
+          echo "---------------------- Waiting for job completion ----------------------"
+          kubectl wait --for=condition=complete job/${{ matrix.job-name }} -n ${namespace} --timeout=600s; status=$? || true
+          [ $status -ne 0 ] && kubectl get pods -n ${namespace} --show-labels && kubectl describe pod -ljob-name=${job_name} -n ${namespace};
+          [ ! -f /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt ] && kubectl logs job/${{ matrix.job-name }} --all-containers -n ${namespace} || \
+            rm -vf /tmp/logs_stramed-${namespace}-${{ matrix.job-name }}.txt
+          kill %1 2>/dev/null && echo "Stopped log streaming" || true
+          exit $status

--- a/.github/workflows/k8s-seed-data.yml
+++ b/.github/workflows/k8s-seed-data.yml
@@ -1,18 +1,18 @@
 name: Seed data (k8s)
-run-name: "Seed data to ${{ inputs.environment }} environment"
+run-name: 'Seed data to ${{ inputs.environment }} environment'
 on:
-    workflow_dispatch:
-      inputs:   
-        environment:
-          description: "Target environment"
-          required: true
-          default: "e2e"
-          type: string
-    workflow_call:
-      inputs:
-        environment:
-          required: true
-          type: string
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'e2e'
+        type: string
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 
 jobs:
   seed:
@@ -23,43 +23,29 @@ jobs:
       - k8s
       - e2e
     steps:
-        - name: Get helm release values and Quote specific fields that are commonly numeric
-          run: |
-            helm get values opencrvs -n ${namespace} -ojson | \
-              jq '
-                # Quote image tags
-                if has("image") and (.image | has("tag")) and (.image.tag | type == "number") then
-                  .image.tag = (.image.tag | tostring)
-                else . end |
-                # Quote version numbers
-                if has("version") and (.version | type == "number") then
-                  .version = (.version | tostring)
-                else . end |
-                # Quote port numbers if needed (optional)
-                if has("service") and (.service | has("port")) and (.service.port | type == "number") then
-                  .service.port = (.service.port | tostring)
-                else . end
-              ' > ${namespace}.json
-        - name: Seeding data
-          run: |
-            kubectl delete job -n ${namespace} --ignore-not-found=true data-seed
-            helm template -f ${namespace}.json \
-                --set data_seed.enabled=true \
-                --namespace ${namespace} \
-                -s templates/data-seed-job.yaml \
-                oci://ghcr.io/opencrvs/opencrvs-services:0.1.29 | kubectl apply --wait -n ${namespace} -f -
+      - name: Get helm release values and Quote specific fields that are commonly numeric
+        run: |
+          helm get values opencrvs -n ${namespace} -ojson > ${namespace}.json
+      - name: Seeding data
+        run: |
+          kubectl delete job -n ${namespace} --ignore-not-found=true data-seed
+          helm template -f ${namespace}.json \
+              --set data_seed.enabled=true \
+              --namespace ${namespace} \
+              -s templates/data-seed-job.yaml \
+              oci://ghcr.io/opencrvs/opencrvs-services:0.1.29 | kubectl apply --wait -n ${namespace} -f -
 
-        - name: Checking data-seed job status
-          run: |
-            while true; do
-              kubectl wait --for=condition=ready pod -ljob-name=data-seed --timeout=300s -n ${namespace} && \
-              kubectl logs job/data-seed --all-containers -f -n ${namespace} && \
-              touch /tmp/logs_stramed-${namespace}-data-seed.txt  || break;
-              sleep 10; done &
-            echo "---------------------- Waiting for job completion ----------------------"
-            kubectl wait --for=condition=complete job/data-seed -n ${namespace} --timeout=600s; status=$? || true
-            [ $status -ne 0 ] && kubectl get pods -n ${namespace} --show-labels && kubectl describe pod -ljob-name=${job_name} -n ${namespace};
-            [ ! -f /tmp/logs_stramed-${namespace}-data-seed.txt ] && kubectl logs job/data-seed --all-containers -n ${namespace} || \
-              rm -vf /tmp/logs_stramed-${namespace}-data-seed.txt
-            kill %1 2>/dev/null && echo "Stopped log streaming" || true
-            exit $status
+      - name: Checking data-seed job status
+        run: |
+          while true; do
+            kubectl wait --for=condition=ready pod -ljob-name=data-seed --timeout=300s -n ${namespace} && \
+            kubectl logs job/data-seed --all-containers -f -n ${namespace} && \
+            touch /tmp/logs_stramed-${namespace}-data-seed.txt  || break;
+            sleep 10; done &
+          echo "---------------------- Waiting for job completion ----------------------"
+          kubectl wait --for=condition=complete job/data-seed -n ${namespace} --timeout=600s; status=$? || true
+          [ $status -ne 0 ] && kubectl get pods -n ${namespace} --show-labels && kubectl describe pod -ljob-name=${job_name} -n ${namespace};
+          [ ! -f /tmp/logs_stramed-${namespace}-data-seed.txt ] && kubectl logs job/data-seed --all-containers -n ${namespace} || \
+            rm -vf /tmp/logs_stramed-${namespace}-data-seed.txt
+          kill %1 2>/dev/null && echo "Stopped log streaming" || true
+          exit $status


### PR DESCRIPTION
The conversion has been moved to the usage site where the tags are converted to strings before being used.
This was mainly encountered due to deprecating "image.tag" in favor of "platform.tag" but not handling the to_string conversion in the relevant places. 
https://github.com/opencrvs/opencrvs-helm-charts/pull/53