### PR TITLE
chore: add explicit image

### DIFF
--- a/k8s-env/dependencies/values.yaml
+++ b/k8s-env/dependencies/values.yaml
@@ -16,6 +16,7 @@ mongodb:
   use_default_credentials: false
 
 postgres:
+  image: chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
   use_default_credentials: false
 
 monitoring:


### PR DESCRIPTION
dependencies have not been installed in months.  postgres did not get the values from helm-charts, which had the custom image defined.

Define the same custom image explicitly.