### PR TITLE
Remove auth.* public subdomain — auth is now only reachable via gateway proxy

### DIFF
--- a/infrastructure/environments/derived-variables.ts
+++ b/infrastructure/environments/derived-variables.ts
@@ -7,13 +7,6 @@ export const derivedVariables = [
     scope: 'ENVIRONMENT'
   },
   {
-    name: 'AUTH_HOST',
-    valueLabel: 'AUTH_HOST',
-    valueType: 'VARIABLE',
-    type: 'disabled',
-    scope: 'ENVIRONMENT'
-  },
-  {
     name: 'COUNTRY_CONFIG_HOST',
     valueLabel: 'COUNTRY_CONFIG_HOST',
     valueType: 'VARIABLE',

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -890,22 +890,6 @@ ALL_QUESTIONS.push(
       },
       {
         type: 'VARIABLE' as const,
-        name: 'AUTH_HOST',
-        value: answerOrExisting(
-          allAnswers.domain,
-          findExistingValue('DOMAIN', 'VARIABLE', 'ENVIRONMENT', existingValues),
-          (val) => `https://auth.${val}`
-        ),
-        didExist: findExistingValue(
-          'AUTH_HOST',
-          'VARIABLE',
-          'ENVIRONMENT',
-          existingValues
-        ),
-        scope: 'ENVIRONMENT' as const
-      },
-      {
-        type: 'VARIABLE' as const,
         name: 'COUNTRY_CONFIG_HOST',
         value: answerOrExisting(
           allAnswers.domain,


### PR DESCRIPTION
# Auth Subdomain Removal — Behavior Before & After

**Ticket:** [#12734](https://github.com/opencrvs/opencrvs-core/issues/12734)
**Branch:** `ocrvs-12734` (opencrvs-core, opencrvs-countryconfig, opencrvs-farajaland, e2e)
**Commit (all repos):** _Remove auth.* public subdomain — auth is now only reachable via gateway proxy_

---

## Summary

The auth service used to be reachable two ways: directly from the public internet
on its own `auth.{hostname}` subdomain, **and** through the gateway proxy at
`gateway.{hostname}/auth/*`. This change removes the public subdomain entirely.
Auth is now reachable **only** through the gateway.

Functionally this is invisible to real users and internal services — they already
used the gateway path. What changes is the attack surface: auth's only public
entry point is now the gateway, where rate limiting, CORS, and request validation
are enforced.

---

## The core change: one fewer public door

### Before

The auth service had **two** entry points:

1. **Directly, from the public internet** — a dedicated Traefik route on its own subdomain:
   - **K8s:** an `IngressRoute` matching `Host(auth.{hostname})` → auth pod port 4040
   - **Docker (countryconfig/farajaland):** Traefik labels publishing `Host(auth.{hostname})` with its own TLS cert
   - **e2e:** `Host(auth.${STACK}.{{hostname}})` with a wildcard cert

   `https://auth.register.example.org/authenticate` resolved, had a real TLS
   certificate, and hit auth **directly — bypassing the gateway**.

2. **Through the gateway proxy** — `https://gateway.{hostname}/auth/*` → auth internally.

Because browsers *could* hit auth directly cross-origin, auth ran its own **CORS
whitelist** (`packages/auth/src/server.ts`) allowing origins
`COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, and `CLIENT_APP_URL`. Those three env
vars were injected into the auth container in every deployment.

A special guard also existed: `/internal/reindexing-token` was explicitly *blocked*
at the subdomain (the `block-auth-reindexing-token` router with an invalid-IP
whitelist), because the subdomain was otherwise wide open and that one internal
endpoint had to stay private.

### After

The auth service is reachable **only** through the gateway proxy at
`https://gateway.{hostname}/auth/*`.

- The `IngressRoute` is deleted (K8s); the Docker Traefik labels are replaced with
  `traefik.enable=false` (auth is no longer published on *any* host).
- `https://auth.{hostname}/...` now **fails to resolve / 404s** — there is no route
  and no cert provisioned for that subdomain anymore.
- The auth pod keeps running unchanged inside the cluster; only its public entry
  point is gone. The gateway still reaches it over the internal network.

---

## Consequences that follow

### CORS is now `cors: false` on auth

No browser ever has auth as an origin anymore — everything is same-origin
`/auth/*` through the gateway, and the gateway owns CORS for external clients. The
whitelist became dead logic. Auth now sees only server-to-server traffic, so it
rejects all cross-origin browser preflights outright.

The three env vars (`COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, `CLIENT_APP_URL`)
are removed from both the auth code and every deployment manifest.
`COUNTRY_CONFIG_URL_INTERNAL` is the only one kept (still used for the server-side
roles lookup).

### The `/internal/reindexing-token` block is no longer needed in auth's config

Before, that endpoint had to be explicitly firewalled because the subdomain exposed
everything. Now that auth has no public route at all, the special block-rule is
simply gone — nothing on auth is publicly exposed.

> Note: farajaland keeps a *separate* `block-internal` rule for
> `countryconfig.../internal` — that is unrelated and was left untouched.

---

## Risk-elimination edits (callers that used the subdomain)

These would have broken if left alone, since they pointed at the now-dead subdomain:

| Caller | Before | After |
|--------|--------|-------|
| **data-seeder** (`opencrvs-core/packages/data-seeder/src/index.ts`) | `POST {AUTH_HOST}/authenticate-super-user` | `POST {GATEWAY_HOST}/auth/authenticate-super-user`; `AUTH_HOST` env removed |
| **farajaland data generator** (`src/data-generator/generate-tennis-club.js`) | `https://auth.farajaland-dev.../authenticate` & `/verifyCode` | `https://gateway.farajaland-dev.../auth/authenticate` & `/auth/verifyCode` |
| **core E2E CI** (`.github/workflows/cd-manual-e2e.yml`) | `CYPRESS_AUTH_URL=https://auth.farajaland-staging...` | `...gateway.farajaland-staging.../auth/` |
| **e2e seed CI** (`.github/workflows/seed-data.yml`) | passed `AUTH_HOST` to seeder | removed (seeder uses `GATEWAY_HOST`) |
| **env provisioning** (`setup-environment.ts` ×3 repos) | generated `AUTH_HOST=https://auth.{domain}` → DNS A-record + TLS cert for the subdomain | removed — no orphan DNS/cert provisioned for `auth.*` |

---

## What is unchanged

- **End-user login/auth flows** — browsers already called `/api/auth/*` (relative,
  via the gateway). No user-visible behavior change; tokens, refresh, and invalidate
  all still work.
- **Internal server-to-server calls** that used Kubernetes/Docker DNS
  (`auth:4040` / `auth.{ns}.svc.cluster.local`) — those never touched the subdomain
  and are untouched.
- **MOSIP** — verified to use internal docker service URLs (`http://mosip-mock:...`),
  not the auth subdomain, so its callbacks are unaffected.

---

## Net effect

Functionally identical for real users and internal services, but the auth service's
public attack surface collapses from "its own internet-facing subdomain with its own
cert and its own CORS/header middleware" down to "internal-only, reachable solely
through the gateway." Rate limiting, CORS, and request validation at the gateway
become the single enforced entry point, and the deployment stops provisioning a DNS
record + TLS certificate that no longer serves anything.

---

## Files changed

### opencrvs-core
- `charts/opencrvs-services/templates/auth-deployment.yaml` — removed `IngressRoute`; removed CORS env vars
- `packages/auth/src/environment.ts` — removed `COUNTRY_CONFIG_URL_EXTERNAL`, `LOGIN_URL`, `CLIENT_APP_URL`
- `packages/auth/src/server.ts` — `cors` whitelist → `cors: false`
- `packages/data-seeder/src/environment.ts` — removed `AUTH_HOST`
- `packages/data-seeder/src/index.ts` — auth call rerouted through `GATEWAY_HOST`
- `.github/workflows/cd-manual-e2e.yml` — `CYPRESS_AUTH_URL` → gateway path

### opencrvs-countryconfig
- `infrastructure/docker-compose.deploy.yml` — removed auth Traefik labels + CORS env vars (`traefik.enable=false`)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)

### opencrvs-farajaland
- `infrastructure/docker-compose.deploy.yml` — same as countryconfig (kept unrelated `block-internal` rule)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)
- `src/data-generator/generate-tennis-club.js` — auth calls rerouted through gateway

### e2e
- `infrastructure/docker-compose.app.yml` — removed auth Traefik labels (`traefik.enable=false`)
- `infrastructure/environments/setup-environment.ts` — removed `AUTH_HOST` (derived + computed)
- `.github/workflows/seed-data.yml` — removed `AUTH_HOST` env var

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
