### PR TITLE
ci: point per-PR e2e at core/testland instead of farajaland

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -1,5 +1,5 @@
 name: 01. Deploy & run E2E
-run-name: 'E2E by ${{ github.event.client_payload.actor || github.actor }} to ${{ github.event.client_payload.stack || github.event.inputs.stack }} (core: ${{ github.event.client_payload.core-image-tag || inputs.core-image-tag }}, testland: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }})'
+run-name: 'E2E by ${{ github.event.client_payload.actor || github.actor }} to ${{ github.event.client_payload.stack || github.event.inputs.stack }} (core: ${{ github.event.client_payload.core-image-tag || inputs.core-image-tag }}, testland: ${{ github.event.client_payload.testland-image-tag || inputs.testland-image-tag }})'
 on:
   repository_dispatch:
     types: [run_e2e]
@@ -9,8 +9,8 @@ on:
         description: Core image tag
         required: true
         default: 'v2.0.0'
-      countryconfig-image-tag:
-        description: Your Country Config DockerHub image tag
+      testland-image-tag:
+        description: Testland (packages/testland) image tag; equals the core image tag
         required: true
         default: 'v2.0.0'
       stack:
@@ -79,26 +79,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: 'opencrvs/opencrvs-testland'
-          fetch-depth: 0
+          repository: 'opencrvs/opencrvs-core'
+          ref: ${{ github.event.client_payload.core-branch || inputs.core-branch }}
+          sparse-checkout: packages/testland
 
-      - name: Checkout country branch
-        run: |
-          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
-      - name: Set up Node.js from country .nvmrc
+      - name: Set up Node.js from testland .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version-file: .nvmrc
+          node-version-file: packages/testland/.nvmrc
 
       - name: Cache Node.js dependencies
         uses: actions/cache@v6
         id: cache
         with:
           path: |
-            node_modules
+            packages/testland/node_modules
             ~/.cache/yarn/v6
             ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+          key: ${{ github.event.client_payload.testland-image-tag || inputs.testland-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
@@ -108,14 +106,14 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: yarn
+          command: cd packages/testland && yarn
       - uses: nick-fields/retry@v4
         name: Install Playwright Browsers
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npx playwright install --with-deps
+          command: cd packages/testland && npx playwright install --with-deps
 
   deploy:
     uses: ./.github/workflows/k8s-deploy.yml
@@ -125,7 +123,7 @@ jobs:
       core-image-tag: ${{ github.event.client_payload.core-image-tag || inputs.core-image-tag }}
       core-branch: ${{ github.event.client_payload.core-branch || inputs.core-branch }}
       branch: ${{ github.event.client_payload.branch || inputs.branch }}
-      countryconfig-image-tag: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+      testland-image-tag: ${{ github.event.client_payload.testland-image-tag || inputs.testland-image-tag }}
       environment: ${{ github.event.client_payload.stack || inputs.stack }}
       keep-e2e: ${{ github.event.client_payload.keep-e2e == 'true' || github.event.client_payload.keep-e2e == true || inputs.keep-e2e || false }}
     secrets: inherit
@@ -166,39 +164,39 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: 'opencrvs/opencrvs-testland'
-          fetch-depth: 0
+          repository: 'opencrvs/opencrvs-core'
+          ref: ${{ github.event.client_payload.core-branch || inputs.core-branch }}
+          sparse-checkout: packages/testland
 
-      - name: Checkout country branch
-        run: |
-          git checkout ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
-      - name: Set up Node.js from country .nvmrc
+      - name: Set up Node.js from testland .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version-file: .nvmrc
+          node-version-file: packages/testland/.nvmrc
 
       - name: Cache Node.js dependencies
         uses: actions/cache@v6
         id: cache
         with:
           path: |
-            node_modules
+            packages/testland/node_modules
             ~/.cache/yarn/v6
             ~/.cache/ms-playwright
-          key: ${{ github.event.client_payload.countryconfig-image-tag || inputs.countryconfig-image-tag }}
+          key: ${{ github.event.client_payload.testland-image-tag || inputs.testland-image-tag }}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: packages/testland
         run: yarn
       - uses: nick-fields/retry@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npx playwright install --with-deps
+          command: cd packages/testland && npx playwright install --with-deps
       - name: Run Playwright Tests
+        working-directory: packages/testland
         run: |
           export NODE_EXTRA_CA_CERTS=/tmp/letsencrypt-stg-root-x1.pem
           curl -s -o $NODE_EXTRA_CA_CERTS https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem
@@ -207,6 +205,7 @@ jobs:
           DOMAIN: '${{ github.event.client_payload.stack || inputs.stack }}.e2e-k8s.${{ vars.DOMAIN }}'
       - id: ctrf_check
         if: '!cancelled()'
+        working-directory: packages/testland
         run: |
           [ -d ctrf ] && \
            echo "ctrf=true" >> $GITHUB_OUTPUT || \
@@ -214,7 +213,7 @@ jobs:
       - name: Publish Test Report
         uses: ctrf-io/github-test-reporter@v1
         with:
-          report-path: './ctrf/*.json'
+          report-path: './packages/testland/ctrf/*.json'
           github-report: true
           summary-report: true
           test-report: true
@@ -224,7 +223,7 @@ jobs:
         if: '!cancelled()'
         with:
           name: playwright-report-${{ github.event.client_payload.stack || inputs.stack }}-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: playwright-report/
+          path: packages/testland/playwright-report/
           retention-days: 30
 
   get-previous-run:

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -1,11 +1,11 @@
 name: 04. Deploy OpenCRVS
-run-name: 'Deploy OpenCRVS (core: ${{ inputs.core-image-tag }}, country: ${{ inputs.countryconfig-image-tag }})'
+run-name: 'Deploy OpenCRVS (core: ${{ inputs.core-image-tag }}, testland: ${{ inputs.testland-image-tag }})'
 on:
   workflow_call:
     inputs:
       core-image-tag:
         type: string
-      countryconfig-image-tag:
+      testland-image-tag:
         type: string
       environment:
         type: string
@@ -24,8 +24,8 @@ on:
         description: "Tag of the core image"
         required: true
         default: 'develop'
-      countryconfig-image-tag:
-        description: "Tag of the countryconfig image"
+      testland-image-tag:
+        description: "Tag of the testland image"
         required: true
         default: 'develop'
       environment:
@@ -51,7 +51,9 @@ jobs:
     env:
       ENV: ${{ inputs.environment }}
       CORE_IMAGE_TAG: ${{ inputs.core-image-tag }}
-      COUNTRYCONFIG_IMAGE_TAG: ${{ inputs.countryconfig-image-tag }}
+      # Chart-facing var name kept (feeds --set countryconfig.image.tag); value
+      # is now the testland image tag (== core sha).
+      COUNTRYCONFIG_IMAGE_TAG: ${{ inputs.testland-image-tag }}
     runs-on:
       - self-hosted
       - k8s
@@ -74,7 +76,7 @@ jobs:
         run: |
           echo "Deploying environment to https://${{ inputs.environment }}.e2e-k8s.${{ vars.DOMAIN }}" >> $GITHUB_STEP_SUMMARY
           echo "Core image tag: ${{ inputs.core-image-tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "Country config image tag: ${{ inputs.countryconfig-image-tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "Testland image tag: ${{ inputs.testland-image-tag }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Print deployment parameters
         run: |

--- a/k8s-env/opencrvs/values.yaml
+++ b/k8s-env/opencrvs/values.yaml
@@ -71,7 +71,13 @@ client:
    CONTENT_SECURITY_POLICY_WILDCARD: "*.e2e-k8s.opencrvs.dev"
 countryconfig:
   image:
-    name: opencrvs/opencrvs-testland
+    # testland (packages/testland in opencrvs-core), published to ghcr by core's
+    # image matrix. No "/" in the name => inherits platform.repository
+    # (ghcr.io/opencrvs), resolving to ghcr.io/opencrvs/ocrvs-testland (public,
+    # no pull secret needed). The companion assets image consumed by the
+    # data-migration-analytics hook resolves to ocrvs-testland:<tag>-assets.
+    name: ocrvs-testland
+    # tag is overridden at deploy time via --set countryconfig.image.tag=<core sha>
     tag: develop
   env:
     OPENID_PROVIDER_CLAIMS: name,family_name,given_name,middle_name,birthdate,address


### PR DESCRIPTION
## ⚠️ Lockstep merge — do NOT merge alone

This PR must merge **simultaneously** with opencrvs-core's \`impl/slice4-e2e-contract\` branch (per-PR e2e contract flip). Merging either side alone breaks per-PR e2e for every open PR: the dispatch payload keys are renamed on both ends.

## What

Per-PR e2e now consumes testland from **opencrvs-core** (\`packages/testland\`) instead of the external farajaland/testland repo:

- **Dispatch contract**: \`countryconfig-image-tag\` → \`testland-image-tag\` (always equals the core sha — one image matrix builds both).
- **Spec checkout**: e2e testcases via sparse-checkout of \`opencrvs-core:packages/testland\` at \`core-branch\`, replacing the full external repo clone.
- **Image**: \`ghcr.io/opencrvs/ocrvs-testland\` (public, from core's image matrix) replaces the DockerHub image; no pull secret needed. Assets image resolves to \`ocrvs-testland:<tag>-assets\`.
- Core image tag default: v2.0.0 (kept from #172-era bump).

Context: countryconfig-in-core spec §C / e2e repo contract ticket. Supersedes the external-repo rename done in #171 for the per-PR path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)